### PR TITLE
refactor: extract the standard variable replacement logic into its own class.

### DIFF
--- a/mysql_mimic/functions.py
+++ b/mysql_mimic/functions.py
@@ -1,35 +1,22 @@
-from typing import Any, Dict, Mapping, Iterator
+from typing import Any, Mapping, Callable
 from datetime import datetime
 
-
-class Functions(Mapping):
-    def __init__(self, functions: Dict[str, Any]):
-        self._function_mapping = functions
-
-    def __getitem__(self, key: str) -> Any:
-        return self._function_mapping.get(key)
-
-    def __iter__(self) -> Iterator[str]:
-        return iter(self._function_mapping)
-
-    def __len__(self) -> int:
-        return len(self._function_mapping)
+Functions = Mapping[str, Callable[[], Any]]
 
 
-class MySQLDatetimeFunctions(Functions):
-    def __init__(self, timestamp: datetime):
-        functions = {
-            "NOW": lambda: timestamp.strftime("%Y-%m-%d %H:%M:%S"),
-            "CURDATE": lambda: timestamp.strftime("%Y-%m-%d"),
-            "CURTIME": lambda: timestamp.strftime("%H:%M:%S"),
+def mysql_datetime_function_mapping(timestamp: datetime) -> Functions:
+    functions = {
+        "NOW": lambda: timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+        "CURDATE": lambda: timestamp.strftime("%Y-%m-%d"),
+        "CURTIME": lambda: timestamp.strftime("%H:%M:%S"),
+    }
+    functions.update(
+        {
+            "CURRENT_TIMESTAMP": functions["NOW"],
+            "LOCALTIME": functions["NOW"],
+            "LOCALTIMESTAMP": functions["NOW"],
+            "CURRENT_DATE": functions["CURDATE"],
+            "CURRENT_TIME": functions["CURTIME"],
         }
-        functions.update(
-            {
-                "CURRENT_TIMESTAMP": functions["NOW"],
-                "LOCALTIME": functions["NOW"],
-                "LOCALTIMESTAMP": functions["NOW"],
-                "CURRENT_DATE": functions["CURDATE"],
-                "CURRENT_TIME": functions["CURTIME"],
-            }
-        )
-        super().__init__(functions)
+    )
+    return functions

--- a/mysql_mimic/functions.py
+++ b/mysql_mimic/functions.py
@@ -1,0 +1,35 @@
+from typing import Any, Dict, Mapping, Iterator
+from datetime import datetime
+
+
+class Functions(Mapping):
+    def __init__(self, functions: Dict[str, Any]):
+        self._function_mapping = functions
+
+    def __getitem__(self, key: str) -> Any:
+        return self._function_mapping.get(key)
+
+    def __iter__(self) -> Iterator[str]:
+        return iter(self._function_mapping)
+
+    def __len__(self) -> int:
+        return len(self._function_mapping)
+
+
+class MySQLDatetimeFunctions(Functions):
+    def __init__(self, timestamp: datetime):
+        functions = {
+            "NOW": lambda: timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+            "CURDATE": lambda: timestamp.strftime("%Y-%m-%d"),
+            "CURTIME": lambda: timestamp.strftime("%H:%M:%S"),
+        }
+        functions.update(
+            {
+                "CURRENT_TIMESTAMP": functions["NOW"],
+                "LOCALTIME": functions["NOW"],
+                "LOCALTIMESTAMP": functions["NOW"],
+                "CURRENT_DATE": functions["CURDATE"],
+                "CURRENT_TIME": functions["CURTIME"],
+            }
+        )
+        super().__init__(functions)

--- a/mysql_mimic/session.py
+++ b/mysql_mimic/session.py
@@ -526,7 +526,7 @@ class Session(BaseSession):
             current_user=self.username,
             variables=self.variables,
             database=self.database,
-            timestamp=self.timestamp
+            timestamp=self.timestamp,
         )
 
     def timezone(self) -> timezone_:

--- a/mysql_mimic/session.py
+++ b/mysql_mimic/session.py
@@ -389,7 +389,7 @@ class Session(BaseSession):
 
     async def _replace_variables_middleware(self, q: Query) -> AllowedResult:
         """Replace session variables and information functions with their corresponding values"""
-        VariablesProcessor(self._session_context()).replace_variables(q)
+        VariablesProcessor(self._session_context()).replace_variables(q.expression)
         return await q.next()
 
     async def _static_query_middleware(self, q: Query) -> AllowedResult:
@@ -520,12 +520,12 @@ class Session(BaseSession):
     def _show_errors(self, show: exp.Show) -> AllowedResult:
         return [], ["Level", "Code", "Message"]
 
-    def _session_context(self):
+    def _session_context(self) -> SessionContext:
         return SessionContext(
             connection_id=self.connection.connection_id,
-            current_user=self.username,
+            current_user=str(self.username),
             variables=self.variables,
-            database=self.database,
+            database=str(self.database),
             timestamp=self.timestamp,
         )
 

--- a/mysql_mimic/session.py
+++ b/mysql_mimic/session.py
@@ -22,7 +22,6 @@ from mysql_mimic.charset import CharacterSet
 from mysql_mimic.errors import ErrorCode, MysqlError
 from mysql_mimic.intercept import (
     setitem_kind,
-    value_to_expression,
     expression_to_value,
     TRANSACTION_CHARACTERISTICS,
 )
@@ -33,6 +32,7 @@ from mysql_mimic.schema import (
     ensure_info_schema,
 )
 from mysql_mimic.constants import INFO_SCHEMA, KillKind
+from mysql_mimic.variables_processor import SessionContext, VariablesProcessor
 from mysql_mimic.utils import find_dbs
 from mysql_mimic.variables import (
     Variables,
@@ -182,38 +182,6 @@ class Session(BaseSession):
             self._rollback_middleware,
             self._info_schema_middleware,
         ]
-
-        # Information functions.
-        # These will be replaced in the AST with their corresponding values.
-        self._functions = {
-            "CONNECTION_ID": lambda: self.connection.connection_id,
-            "USER": lambda: self.variables.get("external_user"),
-            "CURRENT_USER": lambda: self.username,
-            "VERSION": lambda: self.variables.get("version"),
-            "DATABASE": lambda: self.database,
-            "NOW": lambda: self.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
-            "CURDATE": lambda: self.timestamp.strftime("%Y-%m-%d"),
-            "CURTIME": lambda: self.timestamp.strftime("%H:%M:%S"),
-        }
-        # Synonyms
-        self._functions.update(
-            {
-                "SYSTEM_USER": self._functions["USER"],
-                "SESSION_USER": self._functions["USER"],
-                "SCHEMA": self._functions["DATABASE"],
-                "CURRENT_TIMESTAMP": self._functions["NOW"],
-                "LOCALTIME": self._functions["NOW"],
-                "LOCALTIMESTAMP": self._functions["NOW"],
-                "CURRENT_DATE": self._functions["CURDATE"],
-                "CURRENT_TIME": self._functions["CURTIME"],
-            }
-        )
-        self._constants = {
-            "CURRENT_USER",
-            "CURRENT_TIME",
-            "CURRENT_TIMESTAMP",
-            "CURRENT_DATE",
-        }
 
         # Current database
         self.database = None
@@ -421,47 +389,7 @@ class Session(BaseSession):
 
     async def _replace_variables_middleware(self, q: Query) -> AllowedResult:
         """Replace session variables and information functions with their corresponding values"""
-
-        def _transform(node: exp.Expression) -> exp.Expression:
-            new_node = None
-
-            if isinstance(node, exp.Func):
-                if isinstance(node, exp.Anonymous):
-                    func_name = node.name.upper()
-                else:
-                    func_name = node.sql_name()
-                func = self._functions.get(func_name)
-                if func:
-                    value = func()
-                    new_node = value_to_expression(value)
-            elif isinstance(node, exp.Column) and node.sql() in self._constants:
-                value = self._functions[node.sql()]()
-                new_node = value_to_expression(value)
-            elif isinstance(node, exp.SessionParameter):
-                value = self.variables.get(node.name)
-                new_node = value_to_expression(value)
-
-            if (
-                new_node
-                and isinstance(node.parent, exp.Select)
-                and node.arg_key == "expressions"
-            ):
-                new_node = exp.alias_(new_node, exp.to_identifier(node.sql()))
-
-            return new_node or node
-
-        if isinstance(q.expression, exp.Set):
-            for setitem in q.expression.expressions:
-                if isinstance(setitem.this, exp.Binary):
-                    # In the case of statements like: SET @@foo = @@bar
-                    # We only want to replace variables on the right
-                    setitem.this.set(
-                        "expression",
-                        setitem.this.expression.transform(_transform, copy=True),
-                    )
-        else:
-            q.expression.transform(_transform, copy=False)
-
+        VariablesProcessor(self._session_context()).replace_variables(q)
         return await q.next()
 
     async def _static_query_middleware(self, q: Query) -> AllowedResult:
@@ -591,6 +519,15 @@ class Session(BaseSession):
 
     def _show_errors(self, show: exp.Show) -> AllowedResult:
         return [], ["Level", "Code", "Message"]
+
+    def _session_context(self):
+        return SessionContext(
+            connection_id=self.connection.connection_id,
+            current_user=self.username,
+            variables=self.variables,
+            database=self.database,
+            timestamp=self.timestamp
+        )
 
     def timezone(self) -> timezone_:
         tz = self.variables.get("time_zone")

--- a/mysql_mimic/variable_processor.py
+++ b/mysql_mimic/variable_processor.py
@@ -1,5 +1,6 @@
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Dict
 
 from sqlglot import expressions as exp
 
@@ -39,8 +40,8 @@ variable_constants = {
 }
 
 
-def get_var_assignments(expression: exp.Expression) -> dict[str, str]:
-    """Handles any SET_VAR hints, which set system variables for a single statement"""
+def get_var_assignments(expression: exp.Expression) -> Dict[str, str]:
+    """Returns a dictionary of system variables to replace, as indicated by SET_VAR hints."""
     hints = expression.find_all(exp.Hint)
     if not hints:
         return {}

--- a/mysql_mimic/variable_processor.py
+++ b/mysql_mimic/variable_processor.py
@@ -54,7 +54,7 @@ class VariableProcessor:
         self._expression = expression
 
         # Stores the original system variable values.
-        self._orig: dict[str, str] = {}
+        self._orig: Dict[str, str] = {}
 
         # Information functions.
         # These will be replaced in the AST with their corresponding values.

--- a/mysql_mimic/variable_processor.py
+++ b/mysql_mimic/variable_processor.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict
 
-from mypy.ipc import TracebackType
 from sqlglot import expressions as exp
 
 from mysql_mimic.intercept import value_to_expression, expression_to_value
@@ -91,12 +90,7 @@ class VariableProcessor:
         self._replace_variables()
         return self._session.variables
 
-    def __exit__(
-        self,
-        exc_type: type[BaseException],
-        exc_val: BaseException,
-        exc_tb: TracebackType,
-    ) -> None:
+    def __exit__(self, *args: BaseException) -> None:
         for k, v in self._orig.items():
             self._session.variables.set(k, v)
 

--- a/mysql_mimic/variable_processor.py
+++ b/mysql_mimic/variable_processor.py
@@ -2,6 +2,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Dict
 
+from mypy.ipc import TracebackType
 from sqlglot import expressions as exp
 
 from mysql_mimic.intercept import value_to_expression, expression_to_value
@@ -40,38 +41,22 @@ variable_constants = {
 }
 
 
-def get_var_assignments(expression: exp.Expression) -> Dict[str, str]:
-    """Returns a dictionary of system variables to replace, as indicated by SET_VAR hints."""
-    hints = expression.find_all(exp.Hint)
-    if not hints:
-        return {}
-
-    assignments = {}
-
-    # Iterate in reverse order so higher SET_VAR hints get priority
-    for hint in reversed(list(hints)):
-        set_var_hint = None
-
-        for e in hint.expressions:
-            if isinstance(e, exp.Func) and e.name == "SET_VAR":
-                set_var_hint = e
-                for eq in e.expressions:
-                    assignments[eq.left.name] = expression_to_value(eq.right)
-
-        if set_var_hint:
-            set_var_hint.pop()
-
-        # Remove the hint entirely if SET_VAR was the only expression
-        if not hint.expressions:
-            hint.pop()
-
-    return assignments
-
-
 class VariableProcessor:
+    """
+    This class modifies the query in two ways:
+        1. Processing SET_VAR hints for system variables in the query text
+        2. Replacing certain MySQL functions with their internal representations based on the session context.
+    Once the context manager exits, any system variables modified within the query context are reset to their
+    original values.
+    """
 
-    def __init__(self, session: SessionContext):
+    def __init__(self, session: SessionContext, expression: exp.Expression):
         self._session = session
+        self._expression = expression
+
+        # Stores the original system variable values.
+        self._orig: dict[str, str] = {}
+
         # Information functions.
         # These will be replaced in the AST with their corresponding values.
         self._functions = {
@@ -98,10 +83,54 @@ class VariableProcessor:
             }
         )
 
-    def replace_variables(self, expression: exp.Expression) -> None:
+    def __enter__(self) -> Variables:
+        assignments = self._get_var_assignments()
+        self._orig = {k: self._session.variables.get(k) for k in assignments}
+        for k, v in assignments.items():
+            self._session.variables.set(k, v)
+        self._replace_variables()
+        return self._session.variables
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException],
+        exc_val: BaseException,
+        exc_tb: TracebackType,
+    ) -> None:
+        for k, v in self._orig.items():
+            self._session.variables.set(k, v)
+
+    def _get_var_assignments(self) -> Dict[str, str]:
+        """Returns a dictionary of system variables to replace, as indicated by SET_VAR hints."""
+        hints = self._expression.find_all(exp.Hint)
+        if not hints:
+            return {}
+
+        assignments = {}
+
+        # Iterate in reverse order so higher SET_VAR hints get priority
+        for hint in reversed(list(hints)):
+            set_var_hint = None
+
+            for e in hint.expressions:
+                if isinstance(e, exp.Func) and e.name == "SET_VAR":
+                    set_var_hint = e
+                    for eq in e.expressions:
+                        assignments[eq.left.name] = expression_to_value(eq.right)
+
+            if set_var_hint:
+                set_var_hint.pop()
+
+            # Remove the hint entirely if SET_VAR was the only expression
+            if not hint.expressions:
+                hint.pop()
+
+        return assignments
+
+    def _replace_variables(self) -> None:
         """Replaces certain system variables with information provided from the session context."""
-        if isinstance(expression, exp.Set):
-            for setitem in expression.expressions:
+        if isinstance(self._expression, exp.Set):
+            for setitem in self._expression.expressions:
                 if isinstance(setitem.this, exp.Binary):
                     # In the case of statements like: SET @@foo = @@bar
                     # We only want to replace variables on the right
@@ -110,7 +139,7 @@ class VariableProcessor:
                         setitem.this.expression.transform(self._transform, copy=True),
                     )
         else:
-            expression.transform(self._transform, copy=False)
+            self._expression.transform(self._transform, copy=False)
 
     def _transform(self, node: exp.Expression) -> exp.Expression:
         new_node = None

--- a/mysql_mimic/variables_processor.py
+++ b/mysql_mimic/variables_processor.py
@@ -68,9 +68,9 @@ class VariablesProcessor:
             "CURRENT_DATE",
         }
 
-    def replace_variables(self, q):
-        if isinstance(q.expression, exp.Set):
-            for setitem in q.expression.expressions:
+    def replace_variables(self, expression: exp.Expression) -> None:
+        if isinstance(expression, exp.Set):
+            for setitem in expression.expressions:
                 if isinstance(setitem.this, exp.Binary):
                     # In the case of statements like: SET @@foo = @@bar
                     # We only want to replace variables on the right
@@ -79,7 +79,7 @@ class VariablesProcessor:
                         setitem.this.expression.transform(self._transform, copy=True),
                     )
         else:
-            q.expression.transform(self._transform, copy=False)
+            expression.transform(self._transform, copy=False)
 
     def _transform(self, node: exp.Expression) -> exp.Expression:
         new_node = None

--- a/mysql_mimic/variables_processor.py
+++ b/mysql_mimic/variables_processor.py
@@ -2,7 +2,7 @@ from datetime import datetime
 
 from sqlglot import expressions as exp
 
-from mysql_mimic.intercept import value_to_expression, expression_to_value
+from mysql_mimic.intercept import value_to_expression
 from mysql_mimic.variables import Variables
 
 
@@ -15,13 +15,19 @@ class SessionContext:
     variables: Variables
     timestamp: datetime
 
-    def __init__(self, connection_id: int, current_user: str, variables: Variables, database: str,
-                 timestamp: datetime):
+    def __init__(
+        self,
+        connection_id: int,
+        current_user: str,
+        variables: Variables,
+        database: str,
+        timestamp: datetime,
+    ):
         self.connection_id = connection_id
-        self.external_user = variables.get('external_user')
+        self.external_user = variables.get("external_user")
         self.variables = variables
         self.current_user = current_user
-        self.version = variables.get('version')
+        self.version = variables.get("version")
         self.database = database
         self.timestamp = timestamp
 

--- a/mysql_mimic/variables_processor.py
+++ b/mysql_mimic/variables_processor.py
@@ -1,0 +1,104 @@
+from datetime import datetime
+
+from sqlglot import expressions as exp
+
+from mysql_mimic.intercept import value_to_expression, expression_to_value
+from mysql_mimic.variables import Variables
+
+
+class SessionContext:
+    connection_id: int
+    external_user: str
+    current_user: str
+    version: str
+    database: str
+    variables: Variables
+    timestamp: datetime
+
+    def __init__(self, connection_id: int, current_user: str, variables: Variables, database: str,
+                 timestamp: datetime):
+        self.connection_id = connection_id
+        self.external_user = variables.get('external_user')
+        self.variables = variables
+        self.current_user = current_user
+        self.version = variables.get('version')
+        self.database = database
+        self.timestamp = timestamp
+
+
+class VariablesProcessor:
+
+    def __init__(self, session: SessionContext):
+        self._session = session
+        # Information functions.
+        # These will be replaced in the AST with their corresponding values.
+        self._functions = {
+            "CONNECTION_ID": lambda: session.connection_id,
+            "USER": lambda: session.external_user,
+            "CURRENT_USER": lambda: session.current_user,
+            "VERSION": lambda: session.version,
+            "DATABASE": lambda: session.database,
+            "NOW": lambda: session.timestamp.strftime("%Y-%m-%d %H:%M:%S"),
+            "CURDATE": lambda: session.timestamp.strftime("%Y-%m-%d"),
+            "CURTIME": lambda: session.timestamp.strftime("%H:%M:%S"),
+        }
+        # Synonyms
+        self._functions.update(
+            {
+                "SYSTEM_USER": self._functions["USER"],
+                "SESSION_USER": self._functions["USER"],
+                "SCHEMA": self._functions["DATABASE"],
+                "CURRENT_TIMESTAMP": self._functions["NOW"],
+                "LOCALTIME": self._functions["NOW"],
+                "LOCALTIMESTAMP": self._functions["NOW"],
+                "CURRENT_DATE": self._functions["CURDATE"],
+                "CURRENT_TIME": self._functions["CURTIME"],
+            }
+        )
+        self._constants = {
+            "CURRENT_USER",
+            "CURRENT_TIME",
+            "CURRENT_TIMESTAMP",
+            "CURRENT_DATE",
+        }
+
+    def replace_variables(self, q):
+        if isinstance(q.expression, exp.Set):
+            for setitem in q.expression.expressions:
+                if isinstance(setitem.this, exp.Binary):
+                    # In the case of statements like: SET @@foo = @@bar
+                    # We only want to replace variables on the right
+                    setitem.this.set(
+                        "expression",
+                        setitem.this.expression.transform(self._transform, copy=True),
+                    )
+        else:
+            q.expression.transform(self._transform, copy=False)
+
+    def _transform(self, node: exp.Expression) -> exp.Expression:
+        new_node = None
+
+        if isinstance(node, exp.Func):
+            if isinstance(node, exp.Anonymous):
+                func_name = node.name.upper()
+            else:
+                func_name = node.sql_name()
+            func = self._functions.get(func_name)
+            if func:
+                value = func()
+                new_node = value_to_expression(value)
+        elif isinstance(node, exp.Column) and node.sql() in self._constants:
+            value = self._functions[node.sql()]()
+            new_node = value_to_expression(value)
+        elif isinstance(node, exp.SessionParameter):
+            value = self._session.variables.get(node.name)
+            new_node = value_to_expression(value)
+
+        if (
+            new_node
+            and isinstance(node.parent, exp.Select)
+            and node.arg_key == "expressions"
+        ):
+            new_node = exp.alias_(new_node, exp.to_identifier(node.sql()))
+
+        return new_node or node


### PR DESCRIPTION
Background for this change: the functionality in _replace_variables_middleware is useful in other contexts for standardizing some of the sql functions in a query. Pulling it into its own class so other repos can use it. Should not change any functionality in mysql-mimic.