### PR TITLE
chore: update sqlglot version and re-enable test.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license="MIT",
     packages=find_packages(include=["mysql_mimic", "mysql_mimic.*"]),
     python_requires=">=3.6",
-    install_requires=["sqlglot>=26.2.0"],
+    install_requires=["sqlglot"],
     extras_require={
         "dev": [
             "aiomysql",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     license="MIT",
     packages=find_packages(include=["mysql_mimic", "mysql_mimic.*"]),
     python_requires=">=3.6",
-    install_requires=["sqlglot>=18.6.0"],
+    install_requires=["sqlglot>=26.2.0"],
     extras_require={
         "dev": [
             "aiomysql",

--- a/tests/test_query.py
+++ b/tests/test_query.py
@@ -778,12 +778,10 @@ async def test_describe_select(
                 }
             ],
         ),
-        # Re-enable this test after sqlglot releases fix.
-        # PR with fix: https://github.com/tobymao/sqlglot/pull/4574
-        # (
-        #     "select database(), schema(), left(user(),instr(concat(user(),'@'), '@')-1)",
-        #     [{"DATABASE()": None, "SCHEMA()": None, "_col_2": "levon_helm"}],
-        # ),
+        (
+            "select database(), schema(), left(user(),instr(concat(user(),'@'), '@')-1)",
+            [{"DATABASE()": None, "SCHEMA()": None, "_col_2": "levon_helm"}],
+        ),
         (queries.DATA_GRIP_PARAMETERS, []),
         (
             queries.DATA_GRIP_TABLES,


### PR DESCRIPTION
The test that was suppressed in https://github.com/barakalon/mysql-mimic/pull/62 can be re-enabled now that the sqlglot fix is in.