### PR TITLE
fix: the len() method of Variables should return the schema length.

### DIFF
--- a/mysql_mimic/variables.py
+++ b/mysql_mimic/variables.py
@@ -79,7 +79,7 @@ class Variables(abc.ABC, MutableMapping[str, Any]):
         raise MysqlError(f"Cannot delete session variable {key}.")
 
     def __iter__(self) -> Iterator[str]:
-        return self._values.__iter__()
+        return self.schema.__iter__()
 
     def __len__(self) -> int:
         return len(self.schema)

--- a/mysql_mimic/variables.py
+++ b/mysql_mimic/variables.py
@@ -82,7 +82,7 @@ class Variables(abc.ABC, MutableMapping[str, Any]):
         return self._values.__iter__()
 
     def __len__(self) -> int:
-        return len(self._values)
+        return len(self.schema)
 
     def get_schema(self, name: str) -> VariableSchema:
         schema = self.schema.get(name)

--- a/mysql_mimic/version.py
+++ b/mysql_mimic/version.py
@@ -1,6 +1,6 @@
 """mysql-mimic version information"""
 
-__version__ = "2.6.3"
+__version__ = "2.6.4"
 
 
 def main(name: str) -> None:

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -34,6 +34,7 @@ def test_parse_timezone() -> None:
 def test_variable_mapping() -> None:
     test_vars = TestVars()
     assert test_vars
+    assert len(test_vars) == 1
 
     assert test_vars.get_variable("foo") == "bar"
     assert test_vars["foo"] == "bar"

--- a/tests/test_variables.py
+++ b/tests/test_variables.py
@@ -33,6 +33,7 @@ def test_parse_timezone() -> None:
 
 def test_variable_mapping() -> None:
     test_vars = TestVars()
+    assert test_vars
 
     assert test_vars.get_variable("foo") == "bar"
     assert test_vars["foo"] == "bar"


### PR DESCRIPTION
The len() method of the Variables class was returning the length of the _values collection, where overridden variable values are stored, and not the length of the schema. This caused the class to erroneously evaluate to False if no variable values are overridden.